### PR TITLE
Use env variable for google play-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 
+### Use environment's Google Service Version (due to crash on Google Service version 12
+
+You can specify googlePlayServicesVersion in "android/gradle.properties". Otherwise, it will take default version e.g. `googlePlayServicesVersion=11.8.0`
+
 ## Usage
 ```javascript
 var PushNotification = require('react-native-push-notification');

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,8 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION = "+"
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
@@ -37,10 +39,11 @@ android {
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
+    compile 'com.google.android.gms:play-services-gcm:$googlePlayServicesVersion'
     compile 'me.leolin:ShortcutBadger:1.1.8@aar'
 }


### PR DESCRIPTION
As google play-services v12.0 is broken we can allow for a workaround. The default behaviour is the same. Please check out https://github.com/idehub/react-native-google-analytics-bridge/pull/229 or https://github.com/react-community/react-native-maps/pull/2047